### PR TITLE
Remove Unnecessary Hidden `redirect_url` Input.

### DIFF
--- a/eu-cookie-law.php
+++ b/eu-cookie-law.php
@@ -148,7 +148,7 @@ class EU_Cookie_Law_Widget extends WP_Widget {
 		// Cookie is valid for 30 days, so the user will be shown the banner again after 30 days
 		setcookie( self::$cookie_name, current_time( 'timestamp' ), time() + self::$cookie_validity, '/' );
 
-		wp_safe_redirect( $_POST['redirect_url'] );
+		wp_safe_redirect( wp_get_referer() );
 	}
 }
 

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -8,7 +8,6 @@
 	<form action="<?php echo esc_attr( $blog_url ); ?>" method="post">
 		<?php wp_nonce_field( 'eucookielaw' ); ?>
 		<input type="hidden" name="eucookielaw" value="accept" />
-		<input type="hidden" name="redirect_url" value="<?php echo esc_attr( $_SERVER['REQUEST_URI'] ) ?>" />
 		<input type="submit" value="<?php echo esc_attr( $instance['button'] ) ?>" class="accept" />
 
 		<?php if ( $instance['text'] == 'default' || empty( $instance['customtext'] ) ) {


### PR DESCRIPTION
`wp_nonce_field()` already outputs a `<input name="_wp_http_referer">`.  Remove the extra `<input name="redirect_url" />`.
